### PR TITLE
Format error messages better.

### DIFF
--- a/pgutil.go
+++ b/pgutil.go
@@ -273,6 +273,6 @@ func QueryStrings(db *sql.DB, query string) (chan map[string]string, []string) {
 
 func check(msg string, err error) {
 	if err != nil {
-		log.Fatal("Error "+msg, err)
+		log.Fatal("Error "+msg+": ", err)
 	}
 }


### PR DESCRIPTION
Without this change, I was getting confusing errors like

  Error running querypq: syntax error at or near "COLLATE"

Now it becomes

  Error running query: pq: syntax error at or near "COLLATE"

Much nicer!
